### PR TITLE
update doc to make it more clear

### DIFF
--- a/doc_source/dp-copydata-mysql-console.md
+++ b/doc_source/dp-copydata-mysql-console.md
@@ -12,7 +12,7 @@ You can create a pipeline to copy data from a MySQL table to a file in an Amazon
 
 ## Create the Pipeline<a name="dp-copydata-mysql-define-objects-console"></a>
 
-First, create the pipeline\. The pipeline must be created in the same region as your target RDS instance\.
+First, create the pipeline\. The EC2 instance launched as a part of pipeline must be created in the same region as your target RDS instance\.
 
 **To create your pipeline**
 


### PR DESCRIPTION
DP can be in any of the regions but the RDS and EC2 instance launched by DataPipeline should be in same region in case RDS is not publicly accessible(to add a security group and to be in same VPC)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
